### PR TITLE
feat: 支持cxxTurboModule

### DIFF
--- a/harmony/doc-viewer/src/main/cpp/CMakeLists.txt
+++ b/harmony/doc-viewer/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+file(GLOB rnoh_doc_viewer_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(rnoh_doc_viewer SHARED ${rnoh_doc_viewer_SRC})
+target_include_directories(rnoh_doc_viewer PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(rnoh_doc_viewer PUBLIC rnoh)

--- a/harmony/doc-viewer/src/main/cpp/DocViewerPackage.h
+++ b/harmony/doc-viewer/src/main/cpp/DocViewerPackage.h
@@ -1,0 +1,50 @@
+/**
+ * MIT License
+ *
+ * Copyright (C) 2024 Huawei Device Co., Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "RNOH/Package.h"
+#include "DocViewerTurboModule.h"
+
+using namespace rnoh;
+using namespace facebook;
+
+class NativeRTCDocViewerFactoryDelegate : public TurboModuleFactoryDelegate {
+  public:
+    SharedTurboModule createTurboModule(Context ctx, const std::string &name) const override {
+      if (name == "RNCDocViewer") {
+          return std::make_shared<DocViewerTurboModule>(ctx, name);
+      }
+      return nullptr;
+    }
+};
+
+namespace rnoh {
+
+class DocViewerPackage : public Package {
+  public:
+    DocViewerPackage(Package::Context ctx) : Package(ctx) {}
+    std::unique_ptr<TurboModuleFactoryDelegate> createTurboModuleFactoryDelegate() override {
+        return std::make_unique<NativeRTCDocViewerFactoryDelegate>();
+    }
+};
+} // namespace rnoh

--- a/harmony/doc-viewer/src/main/cpp/DocViewerTurboModule.cpp
+++ b/harmony/doc-viewer/src/main/cpp/DocViewerTurboModule.cpp
@@ -1,0 +1,59 @@
+/**
+ * MIT License
+ *
+ * Copyright (C) 2024 Huawei Device Co., Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "DocViewerTurboModule.h"
+#include "RNOH/ArkTSTurboModule.h"
+
+using namespace rnoh;
+using namespace facebook;
+
+static jsi::Value __hostFunction_DocViewerTurboModule_openDoc(jsi::Runtime &rt, react::TurboModule &turboModule,
+                                                              const jsi::Value *args, size_t count) {
+    {
+        return jsi::Value(static_cast<ArkTSTurboModule &>(turboModule).call(rt, "openDoc", args, count));
+    }
+}
+
+static jsi::Value __hostFunction_DocViewerTurboModule_openDocBinaryinUrl(jsi::Runtime &rt, react::TurboModule &turboModule,
+                                                              const jsi::Value *args, size_t count) {
+    {
+        return jsi::Value(static_cast<ArkTSTurboModule &>(turboModule).call(rt, "openDocBinaryinUrl", args, count));
+    }
+}
+
+
+static jsi::Value __hostFunction_DocViewerTurboModule_openDocb64(jsi::Runtime &rt, react::TurboModule &turboModule,
+                                                              const jsi::Value *args, size_t count) {
+    {
+        return jsi::Value(static_cast<ArkTSTurboModule &>(turboModule).call(rt, "openDocb64", args, count));
+    }
+}
+
+
+DocViewerTurboModule::DocViewerTurboModule(const ArkTSTurboModule::Context ctx, const std::string name)
+    : ArkTSTurboModule(ctx, name) {
+    methodMap_["openDoc"] = MethodMetadata{0, __hostFunction_DocViewerTurboModule_openDoc};
+    methodMap_["openDocBinaryinUrl"] = MethodMetadata{1, __hostFunction_DocViewerTurboModule_openDocBinaryinUrl};
+    methodMap_["openDocb64"] = MethodMetadata{1, __hostFunction_DocViewerTurboModule_openDocb64};
+}

--- a/harmony/doc-viewer/src/main/cpp/DocViewerTurboModule.h
+++ b/harmony/doc-viewer/src/main/cpp/DocViewerTurboModule.h
@@ -1,0 +1,35 @@
+/**
+ * MIT License
+ *
+ * Copyright (C) 2024 Huawei Device Co., Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+// NOTE: This entire file should be codegen'ed.
+#pragma once
+#include "RNOH/ArkTSTurboModule.h"
+
+namespace rnoh {
+
+class JSI_EXPORT DocViewerTurboModule : public ArkTSTurboModule {
+public:
+    DocViewerTurboModule(const ArkTSTurboModule::Context ctx, const std::string name);
+};
+
+}


### PR DESCRIPTION
# Summary

- 支持 cxxTurboModule 解决 0.72.29无法获取Native module的问题

## Test Plan

![image](https://github.com/user-attachments/assets/cc72f086-9ab6-4557-adac-c216626d3fe1)

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
